### PR TITLE
add context switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow setting the cluster context via the --context flag.
+
 ## [0.5.0] - 2021-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ INFO[0000] resources deleted: deployment, podsecuritypolicy, clusterrolebinding,
 
 Absolute path to the kubeconfig file to use.
 
---kube-context (default: current context in kube config)
+--context (default: current context in kube config)
 
-Name of the kube context to use to use. NOTE: not yet implemented.
+Name of the kube context to use.
 
 --name (default: 'debug')
 
@@ -117,6 +117,12 @@ sonar create --networkpolicy
 ```
 
  - also creates a NetworkPolicy which allows all ingress and traffic to the Sonar pod.
+
+```
+sonar create --context foo-context --namespace bar
+```
+
+- create a deployment using context `foo-context` in namespace `bar`.
 
 ### Delete
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,9 +56,9 @@ Global flags:
 
 Absolute path to the kubeconfig file to use.
 
---kube-context (default: current context in kube config)
+--context (default: current context in kube config)
 
-Name of the kube context to use to use. NOTE: not yet implemented.
+Name of the kubernetes context to use.
 
 --name (default: 'debug')
 
@@ -83,7 +83,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&kubeConfig, "kube-config", "", "absolute path to kubeconfig file (default: '$HOME/.kube/config')")
-	rootCmd.PersistentFlags().StringVar(&kubeContext, "kube-context", "", "cluster context to use")
+	rootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "context to use")
 	rootCmd.PersistentFlags().StringVarP(&name, "name", "N", "debug", "resource name (max 50 characters) (automatically prepended with 'sonar-'")
 	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "namespace to operate in")
 }

--- a/service/k8sclient/k8sclient.go
+++ b/service/k8sclient/k8sclient.go
@@ -26,21 +26,29 @@ import (
 )
 
 func New(kubeContext, kubeConfig string) (*kubernetes.Clientset, error) {
-	// Set the kubeconfig to the default location if the path
-	// wasn't provided.
+	// Set the kubeconfig to the default location if the path wasn't provided.
 	if kubeConfig == "" {
 		if home := homedir.HomeDir(); home != "" {
 			kubeConfig = filepath.Join(home, ".kube", "config")
 		}
 	}
 
-	// TODO: implement switching to provided context name
+	// Set defaults for creating a new ClientConfig.
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfig}
+	configOverrides := &clientcmd.ConfigOverrides{}
 
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
+	// Set the context if it was provided.
+	if kubeContext != "" {
+		configOverrides = &clientcmd.ConfigOverrides{CurrentContext: kubeContext}
+	}
+
+	// Create the ClientConfig.
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// Create a Clientset with the provided values.
 	k8sClientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
- rename context flag to align with kubectl
- rename context flag to align with kubectl, add an example for the context flag
- allow the user to provide a specific context to use
- update changelog
