### PR TITLE
add node-exec command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add --node-exec flag to grant access to a host's IPC/net/PID namespaces.
+
 ## [0.6.0] - 2021-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ time as --podsecuritypolicy to have any effect.
 --networkpolicy (default: false)
 
 Apply a NetworkPolicy which allows all ingress and egress traffic.
+
+--node-name (default: none)
+
+Attempt to schedule the pod on the named node.i
+
+--node-exec (default: false)
+
+Create a privileged pod in the node's PID & network namespaces. A node
+name to schedule onto must also be provided. Note that the following
+flags will be ignored: networkpolicy, podsecuritypolicy, privileged.
 ```
 
 #### Examples
@@ -123,6 +133,12 @@ sonar create --context foo-context --namespace bar
 ```
 
 - create a deployment using context `foo-context` in namespace `bar`.
+
+```
+sonar create --node-exec true --node-name worker2 --pod-userid 0
+```
+
+- create a pod with root access to the node named `worker2`.
 
 ### Delete
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -178,6 +178,7 @@ func createSonarDeployment(cmd *cobra.Command, args []string) {
 		Name:              name,
 		Namespace:         namespace,
 		NetworkPolicy:     networkPolicy,
+		NodeExec:          nodeExec,
 		NodeName:          nodeName,
 		PodArgs:           podArgs,
 		PodCommand:        podCommand,

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -36,6 +36,7 @@ const (
 var (
 	image             string
 	networkPolicy     bool
+	nodeExec          bool
 	nodeName          string
 	podArgs           string
 	podCommand        string
@@ -99,7 +100,13 @@ Apply a NetworkPolicy which allows all ingress and egress traffic.
 
 --node-name (default: none)
 
-Attempt to schedule the pod on the named node.`,
+Attempt to schedule the pod on the named node.i
+
+--node-exec (default: false)
+
+Create a privileged pod in the node's PID & network namespaces. A node
+name to schedule onto must also be provided. Note that the following
+flags will be ignored: networkpolicy, podsecuritypolicy, privileged.`,
 		Example: `
 "sonar create" - accept all defaults. Creates a deployment in namespace
 'default' called 'sonar-debug'.  The pod image will be 'busybox:latest'
@@ -114,7 +121,10 @@ a deployment which runs as root. Also creates a PodSecurityPolicy
 (and associated RBAC) which allows the pod to run as root/privileged.
 
 "sonar create --networkpolicy" - creates a NetworkPolicy which allows
-all ingress and traffic to the Sonar pod.`,
+all ingress and traffic to the Sonar pod.
+
+"sonar create --node-exec true --node-name worker2" - creates a pod with
+root access to the node named worker2.`,
 		Run: createSonarDeployment,
 	}
 )
@@ -125,6 +135,7 @@ func init() {
 
 	createCmd.Flags().StringVarP(&image, "image", "i", "busybox:latest", "image name (e.g. glitchcrab/ubuntu-debug:latest)")
 	createCmd.Flags().BoolVar(&networkPolicy, "networkpolicy", false, "create NetworkPolicy (default \"false\")")
+	createCmd.Flags().BoolVar(&nodeExec, "node-exec", false, "spawn a container with root access to the node (default \"false\")")
 	createCmd.Flags().StringVarP(&nodeName, "node-name", "", "", "node name to attempt to schedule the pod on")
 	createCmd.Flags().StringVarP(&podArgs, "pod-args", "a", "24h", "args to pass to pod command")
 	createCmd.Flags().StringVarP(&podCommand, "pod-command", "c", "sleep", "pod command (aka image entrypoint)")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -163,7 +163,7 @@ func createSonarDeployment(cmd *cobra.Command, args []string) {
 	if nodeExec {
 		// Error out if node name was not provided.
 		if nodeName == "" {
-			log.Error("--node-exec also requires --node-name to be provided")
+			log.Fatal("--node-exec also requires --node-name to be provided")
 		}
 
 		networkPolicy = false

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -123,8 +123,9 @@ a deployment which runs as root. Also creates a PodSecurityPolicy
 "sonar create --networkpolicy" - creates a NetworkPolicy which allows
 all ingress and traffic to the Sonar pod.
 
-"sonar create --node-exec true --node-name worker2" - creates a pod with
-root access to the node named worker2.`,
+"sonar create --node-exec true --node-name worker2 \
+    --pod-userid 0" - creates a pod with root access to the node named
+worker2.`,
 		Run: createSonarDeployment,
 	}
 )
@@ -158,6 +159,18 @@ func validateFlags() {
 }
 
 func createSonarDeployment(cmd *cobra.Command, args []string) {
+	// Set sane options if we're exec-ing into a node.
+	if nodeExec {
+		// Error out if node name was not provided.
+		if nodeName == "" {
+			log.Error("--node-exec also requires --node-name to be provided")
+		}
+
+		networkPolicy = false
+		podSecurityPolicy = true
+		privileged = true
+	}
+
 	// Create a SonarConfig
 	sonarConfig := sonarconfig.SonarConfig{
 		Image:             image,

--- a/internal/sonarconfig/sonarconfig.go
+++ b/internal/sonarconfig/sonarconfig.go
@@ -6,6 +6,7 @@ type SonarConfig struct {
 	Name              string
 	Namespace         string
 	NetworkPolicy     bool
+	NodeExec          bool
 	NodeName          string
 	PodArgs           string
 	PodCommand        string

--- a/service/k8sresource/create_deployment.go
+++ b/service/k8sresource/create_deployment.go
@@ -28,10 +28,20 @@ import (
 )
 
 var (
+	hostIPC        = false
+	hostNet        = false
+	hostPID        = false
 	replicas int32 = 1
 )
 
 func NewDeployment(k8sClientSet *kubernetes.Clientset, ctx context.Context, sonarConfig sonarconfig.SonarConfig) (err error) {
+	// Create container in the host namespaces if node-exec is set.
+	if sonarConfig.NodeExec {
+		hostIPC = true
+		hostNet = true
+		hostPID = true
+	}
+
 	// Define the Deployment
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -65,6 +75,9 @@ func NewDeployment(k8sClientSet *kubernetes.Clientset, ctx context.Context, sona
 							},
 						},
 					},
+					HostIPC:            hostIPC,
+					HostNetwork:        hostNet,
+					HostPID:            hostPID,
 					RestartPolicy:      corev1.RestartPolicyAlways,
 					ServiceAccountName: sonarConfig.Name,
 					SecurityContext: &corev1.PodSecurityContext{

--- a/service/k8sresource/create_pod_security_policy.go
+++ b/service/k8sresource/create_pod_security_policy.go
@@ -56,9 +56,6 @@ func NewPodSecurityPolicy(k8sClientSet *kubernetes.Clientset, ctx context.Contex
 					},
 				},
 			},
-			HostIPC:                false,
-			HostNetwork:            false,
-			HostPID:                false,
 			Privileged:             sonarConfig.Privileged,
 			ReadOnlyRootFilesystem: false,
 			RunAsGroup: &policyv1beta1.RunAsGroupStrategyOptions{
@@ -89,6 +86,13 @@ func NewPodSecurityPolicy(k8sClientSet *kubernetes.Clientset, ctx context.Contex
 				"*",
 			},
 		},
+	}
+
+	// Grant access to host namespaces if node-exec is set.
+	if sonarConfig.NodeExec {
+		psp.Spec.HostIPC = true
+		psp.Spec.HostNetwork = true
+		psp.Spec.HostPID = true
 	}
 
 	// Create the PodSecurityPolicy


### PR DESCRIPTION
- add node-exec flag and documentation
- add nodeexec to sonarconfig
- update docs
- add nodeexec to created sonarconfig
- fail out completely if node name not provided with node exec
- create container in host namespaces if node exec is set
- create PSP to allow container in host namespaces if node exec is set
