### PR TITLE
Don't print namespace in log message when no pods are found

### DIFF
--- a/cmd/ls/command.go
+++ b/cmd/ls/command.go
@@ -89,11 +89,7 @@ func runLsCommand(cmd *cobra.Command, args []string) error {
 
 	// Raise a clean exit if no pods found.
 	if len(discoveredPods) == 0 {
-		if a.Globals.Namespace != "" {
-			log.Infof("no pods found with labels %s in namespace %s", strings.Join(searchLabels, ","), a.Globals.Namespace)
-		} else {
-			log.Infof("no pods found with labels %s across all namespaces", strings.Join(searchLabels, ","))
-		}
+		log.Infof("no pods found with labels %s across all namespaces", strings.Join(searchLabels, ","))
 		return nil
 	}
 


### PR DESCRIPTION
closes https://github.com/a7d-corp/a7d-corp/issues/133